### PR TITLE
docs(rpc): nearcore 2.13.0 RPC reference + technical descriptions

### DIFF
--- a/src/data/generatedFastnearPageModels.json
+++ b/src/data/generatedFastnearPageModels.json
@@ -568,7 +568,7 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "description": "Describes information about an access key including the public key."
+                        "description": "Describes information about an access key including its on-trie\nidentifier. For ed25519/secp256k1 access keys the `public_key` field\nis the full public key (string form unchanged from before); for\nML-DSA-65 access keys it is a `ml-dsa-65-hash:...` SHA3-256 digest\n(the full pubkey is not stored on-chain)."
                       }
                     }
                   }
@@ -1814,14 +1814,14 @@
           }
         },
         {
-          "description": "Base64-encoded raw method arguments. JSON-based contracts typically expect UTF-8 bytes of the JSON payload; the example `e30=` is `{}`.",
+          "description": "Base64-encoded argument byte array passed to the method. JSON contracts expect the UTF-8 bytes of the JSON payload (`e30=` decodes to `{}`).",
           "label": "Args Base64",
           "location": "body",
           "name": "args_base64",
           "required": true,
           "schema": {
             "type": "string",
-            "description": "Base64-encoded raw method arguments. JSON-based contracts typically expect UTF-8 bytes of the JSON payload; the example `e30=` is `{}`."
+            "description": "Base64-encoded argument byte array passed to the method. JSON contracts expect the UTF-8 bytes of the JSON payload (`e30=` decodes to `{}`)."
           }
         },
         {
@@ -1930,7 +1930,7 @@
                   "required": true,
                   "schema": {
                     "type": "string",
-                    "description": "Base64-encoded raw method arguments. JSON-based contracts typically expect UTF-8 bytes of the JSON payload; the example `e30=` is `{}`."
+                    "description": "Base64-encoded argument byte array passed to the method. JSON contracts expect the UTF-8 bytes of the JSON payload (`e30=` decodes to `{}`)."
                   }
                 },
                 {
@@ -3092,6 +3092,18 @@
           }
         },
         {
+          "description": "Exclusive start cursor: returns only keys greater than this one. Set to the prior response's `last_key` to page forward; omit to scan from the start of the prefix range.",
+          "label": "After Key Base64",
+          "location": "body",
+          "name": "after_key_base64",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "nullable": true,
+            "description": "Exclusive start cursor: returns only keys greater than this one. Set to the prior response's `last_key` to page forward; omit to scan from the start of the prefix range."
+          }
+        },
+        {
           "description": "Include a Merkle proof for the queried state alongside the values.",
           "label": "Include Proof",
           "location": "body",
@@ -3103,14 +3115,27 @@
           }
         },
         {
-          "description": "Base64-encoded storage key prefix. Use an empty string (`\"\"`) to remove the prefix filter and return all matching contract state values. Large contracts can produce very large responses when no prefix is set.",
+          "description": "Maximum key/value entries per response (≥ 1). Omit for no client-set bound (subject to node limits).",
+          "label": "Limit",
+          "location": "body",
+          "name": "limit",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Maximum key/value entries per response (≥ 1). Omit for no client-set bound (subject to node limits).",
+            "format": "uint32"
+          }
+        },
+        {
+          "description": "Base64-encoded key prefix; returns only trie entries whose key begins with these bytes. Empty string (`\"\"`) removes the filter and returns the entire contract state — expensive on large contracts.",
           "label": "Prefix Base64",
           "location": "body",
           "name": "prefix_base64",
           "required": true,
           "schema": {
             "type": "string",
-            "description": "Base64-encoded storage key prefix. Use an empty string (`\"\"`) to remove the prefix filter and return all matching contract state values. Large contracts can produce very large responses when no prefix is set."
+            "description": "Base64-encoded key prefix; returns only trie entries whose key begins with these bytes. Empty string (`\"\"`) removes the filter and returns the entire contract state — expensive on large contracts."
           }
         }
       ],
@@ -3201,6 +3226,15 @@
                   }
                 },
                 {
+                  "name": "after_key_base64",
+                  "required": false,
+                  "schema": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "Exclusive start cursor: returns only keys greater than this one. Set to the prior response's `last_key` to page forward; omit to scan from the start of the prefix range."
+                  }
+                },
+                {
                   "name": "include_proof",
                   "required": false,
                   "schema": {
@@ -3209,11 +3243,21 @@
                   }
                 },
                 {
+                  "name": "limit",
+                  "required": false,
+                  "schema": {
+                    "type": "integer",
+                    "nullable": true,
+                    "description": "Maximum key/value entries per response (≥ 1). Omit for no client-set bound (subject to node limits).",
+                    "format": "uint32"
+                  }
+                },
+                {
                   "name": "prefix_base64",
                   "required": true,
                   "schema": {
                     "type": "string",
-                    "description": "Base64-encoded storage key prefix. Use an empty string (`\"\"`) to remove the prefix filter and return all matching contract state values. Large contracts can produce very large responses when no prefix is set."
+                    "description": "Base64-encoded key prefix; returns only trie entries whose key begins with these bytes. Empty string (`\"\"`) removes the filter and returns the entire contract state — expensive on large contracts."
                   }
                 },
                 {
@@ -3341,6 +3385,15 @@
                   "values"
                 ],
                 "properties": [
+                  {
+                    "name": "last_key",
+                    "required": false,
+                    "schema": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Continuation cursor — the last key returned. Pass as `after_key_base64` to fetch the next page; absent when the result set is exhausted."
+                    }
+                  },
                   {
                     "name": "proof",
                     "required": false,
@@ -4714,18 +4767,6 @@
                 "type": "object",
                 "properties": [
                   {
-                    "name": "avg_hidden_validator_seats_per_shard",
-                    "required": false,
-                    "schema": {
-                      "type": "array",
-                      "description": "Expected number of hidden validators per shard.",
-                      "items": {
-                        "type": "integer",
-                        "format": "uint64"
-                      }
-                    }
-                  },
-                  {
                     "name": "block_producer_kickout_threshold",
                     "required": false,
                     "schema": {
@@ -4900,18 +4941,6 @@
                     }
                   },
                   {
-                    "name": "num_block_producer_seats_per_shard",
-                    "required": false,
-                    "schema": {
-                      "type": "array",
-                      "description": "Defines number of shards and number of block producer seats per each shard at genesis.",
-                      "items": {
-                        "type": "integer",
-                        "format": "uint64"
-                      }
-                    }
-                  },
-                  {
                     "name": "num_blocks_per_year",
                     "required": false,
                     "schema": {
@@ -4993,6 +5022,15 @@
                       "description": "View that preserves JSON format of the runtime config.",
                       "properties": [
                         {
+                          "name": "account_creation_charge",
+                          "required": false,
+                          "schema": {
+                            "type": "string",
+                            "description": "Amount in yoctoNEAR",
+                            "default": "0"
+                          }
+                        },
+                        {
                           "name": "account_creation_config",
                           "required": false,
                           "schema": {
@@ -5006,6 +5044,15 @@
                           "schema": {
                             "type": "object",
                             "description": "The configuration for congestion control. More info about congestion [here](https://near.github.io/nearcore/architecture/how/receipt-congestion.html?highlight=congestion#receipt-congestion)"
+                          }
+                        },
+                        {
+                          "name": "min_gas_purchase_price",
+                          "required": false,
+                          "schema": {
+                            "type": "string",
+                            "description": "Amount in yoctoNEAR",
+                            "default": "0"
                           }
                         },
                         {
@@ -5075,6 +5122,30 @@
                       "type": "integer",
                       "description": "Number of blocks for which a given transaction is valid",
                       "format": "uint64"
+                    }
+                  },
+                  {
+                    "name": "avg_hidden_validator_seats_per_shard",
+                    "required": false,
+                    "schema": {
+                      "type": "array",
+                      "description": "Expected number of hidden validators per shard.",
+                      "items": {
+                        "type": "integer",
+                        "format": "uint64"
+                      }
+                    }
+                  },
+                  {
+                    "name": "num_block_producer_seats_per_shard",
+                    "required": false,
+                    "schema": {
+                      "type": "array",
+                      "description": "Defines number of shards and number of block producer seats per each shard at genesis.",
+                      "items": {
+                        "type": "integer",
+                        "format": "uint64"
+                      }
                     }
                   }
                 ]
@@ -6854,15 +6925,6 @@
                     }
                   },
                   {
-                    "name": "block_fetch_horizon",
-                    "required": false,
-                    "schema": {
-                      "type": "integer",
-                      "description": "Horizon at which instead of fetching block, fetch full state.",
-                      "format": "uint64"
-                    }
-                  },
-                  {
                     "name": "block_header_fetch_horizon",
                     "required": false,
                     "schema": {
@@ -6875,12 +6937,8 @@
                     "name": "block_production_tracking_delay",
                     "required": false,
                     "schema": {
-                      "type": "array",
-                      "description": "Duration to check for producing / skipping block.",
-                      "items": {
-                        "type": "integer",
-                        "format": "uint64"
-                      }
+                      "type": "string",
+                      "description": "Duration to check for producing / skipping block."
                     }
                   },
                   {
@@ -6954,12 +7012,8 @@
                     "name": "chunk_wait_mult",
                     "required": false,
                     "schema": {
-                      "type": "array",
-                      "description": "Multiplier for the wait time for all chunks to be received.",
-                      "items": {
-                        "type": "integer",
-                        "format": "int32"
-                      }
+                      "type": "string",
+                      "description": "Multiplier for the wait time for all chunks to be received."
                     }
                   },
                   {
@@ -7008,6 +7062,16 @@
                               "secs": 1
                             }
                           }
+                        },
+                        {
+                          "name": "snapshot_every_n_epochs",
+                          "required": false,
+                          "schema": {
+                            "type": "integer",
+                            "description": "Cadence of state snapshots, in epochs. Higher values reduce bucket cost at\nthe expense of potentially longer delta replay during reader bootstrap.",
+                            "format": "uint64",
+                            "default": 10
+                          }
                         }
                       ]
                     }
@@ -7024,12 +7088,8 @@
                     "name": "doomslug_step_period",
                     "required": false,
                     "schema": {
-                      "type": "array",
-                      "description": "Time between running doomslug timer.",
-                      "items": {
-                        "type": "integer",
-                        "format": "uint64"
-                      }
+                      "type": "string",
+                      "description": "Time between running doomslug timer."
                     }
                   },
                   {
@@ -7225,24 +7285,16 @@
                     "name": "max_block_production_delay",
                     "required": false,
                     "schema": {
-                      "type": "array",
-                      "description": "Maximum wait for approvals before producing block.",
-                      "items": {
-                        "type": "integer",
-                        "format": "uint64"
-                      }
+                      "type": "string",
+                      "description": "Maximum wait for approvals before producing block."
                     }
                   },
                   {
                     "name": "max_block_wait_delay",
                     "required": false,
                     "schema": {
-                      "type": "array",
-                      "description": "Maximum duration before skipping given height.",
-                      "items": {
-                        "type": "integer",
-                        "format": "uint64"
-                      }
+                      "type": "string",
+                      "description": "Maximum duration before skipping given height."
                     }
                   },
                   {
@@ -7258,12 +7310,8 @@
                     "name": "min_block_production_delay",
                     "required": false,
                     "schema": {
-                      "type": "array",
-                      "description": "Minimum duration before producing block.",
-                      "items": {
-                        "type": "integer",
-                        "format": "uint64"
-                      }
+                      "type": "string",
+                      "description": "Minimum duration before producing block."
                     }
                   },
                   {
@@ -7331,6 +7379,33 @@
                     }
                   },
                   {
+                    "name": "receipt_to_tx_max_hint_window",
+                    "required": false,
+                    "schema": {
+                      "type": "integer",
+                      "description": "Max `±window` accepted on `EXPERIMENTAL_receipt_to_tx` requests.\nCaps caller's `window`. Applies to pre-first-scan `CenterOut`\nagainst caller's literal hint; ancestor scans use\n`receipt_to_tx_max_hop_distance` instead. Operators raising this\nshould also raise `receipt_to_tx_max_hop_distance` so backward reach\nmatches caller's wider hint scope. Requests with `window` over this\nrejected with `WindowTooLarge`.",
+                      "format": "uint64"
+                    }
+                  },
+                  {
+                    "name": "receipt_to_tx_max_hop_distance",
+                    "required": false,
+                    "schema": {
+                      "type": "integer",
+                      "description": "Max block-distance ancestor scan walks per hop once any scan in\nwalk refreshed `current_height`. Subsequent column-miss scans visit\n`h, h-1, ..., h-max_hop_distance` from most-recent scan-refreshed\nanchor, regardless of column hits between. Anchor included —\nsame-shard local receipts execute in same block as producing\noutcome. Raise if cold archival traffic shows ancestor misses —\ngap = scan-refreshed anchor to producer-outcome height of receipt\nwith missing column row (column hits don't reset anchor). Default\n20 (matches `receipt_to_tx_max_hint_window`).",
+                      "format": "uint64"
+                    }
+                  },
+                  {
+                    "name": "receipt_to_tx_max_outcomes_per_request",
+                    "required": false,
+                    "schema": {
+                      "type": "integer",
+                      "description": "Per-request ceiling on outcome rows the `EXPERIMENTAL_receipt_to_tx`\nhint-fallback scanner reads across hops + shards. Caps cold-RocksDB\nworst case on unauthenticated public endpoint. Default 20_000.\nOperators serving cold archival traffic with deep walks or sparse\noutcomes may raise; benchmark first (see TODO in\n`view_client_actor.rs`). Mid-scan exhaustion fails with\n`BudgetExceeded { scanned, limit }`.",
+                      "format": "uint64"
+                    }
+                  },
+                  {
                     "name": "resharding_config",
                     "required": false,
                     "schema": {
@@ -7360,6 +7435,14 @@
                     "schema": {
                       "type": "boolean",
                       "description": "Save observed instances of ChunkStateWitness to the database in DBCol::LatestChunkStateWitnesses.\nSaving the latest witnesses is useful for analysis and debugging.\nThis option can cause extra load on the database and is not recommended for production use."
+                    }
+                  },
+                  {
+                    "name": "save_receipt_to_tx",
+                    "required": false,
+                    "schema": {
+                      "type": "boolean",
+                      "description": "Whether to persist receipt-to-tx origin mappings to disk or not."
                     }
                   },
                   {
@@ -7481,14 +7564,6 @@
                     }
                   },
                   {
-                    "name": "state_sync_enabled",
-                    "required": false,
-                    "schema": {
-                      "type": "boolean",
-                      "description": "Whether to use the State Sync mechanism.\nIf disabled, the node will do Block Sync instead of State Sync."
-                    }
-                  },
-                  {
                     "name": "state_sync_external_backoff",
                     "required": false,
                     "schema": {
@@ -7597,6 +7672,15 @@
                     }
                   },
                   {
+                    "name": "transaction_pool_strict_nonce_ttl_blocks",
+                    "required": false,
+                    "schema": {
+                      "type": "integer",
+                      "description": "TTL in blocks for gapped strict-nonce transactions in the pool. Transactions with a\nnonce gap whose block_hash is older than this many blocks are evicted during\nprepare_transactions.",
+                      "format": "uint64"
+                    }
+                  },
+                  {
                     "name": "transaction_request_handler_threads",
                     "required": false,
                     "schema": {
@@ -7686,6 +7770,23 @@
                       "type": "integer",
                       "description": "Number of threads for ViewClientActor pool.",
                       "format": "uint"
+                    }
+                  },
+                  {
+                    "name": "block_fetch_horizon",
+                    "required": false,
+                    "schema": {
+                      "type": "integer",
+                      "description": "Horizon at which instead of fetching block, fetch full state.",
+                      "format": "uint64"
+                    }
+                  },
+                  {
+                    "name": "state_sync_enabled",
+                    "required": false,
+                    "schema": {
+                      "type": "boolean",
+                      "description": "Whether to use the State Sync mechanism.\nIf disabled, the node will do Block Sync instead of State Sync."
                     }
                   },
                   {
@@ -8455,8 +8556,6 @@
                   "chain_id",
                   "genesis_height",
                   "num_block_producer_seats",
-                  "num_block_producer_seats_per_shard",
-                  "avg_hidden_validator_seats_per_shard",
                   "dynamic_resharding",
                   "epoch_length",
                   "gas_limit",
@@ -8475,18 +8574,6 @@
                   "fishermen_threshold"
                 ],
                 "properties": [
-                  {
-                    "name": "avg_hidden_validator_seats_per_shard",
-                    "required": true,
-                    "schema": {
-                      "type": "array",
-                      "description": "Expected number of hidden validators per shard.",
-                      "items": {
-                        "type": "integer",
-                        "format": "uint64"
-                      }
-                    }
-                  },
                   {
                     "name": "block_producer_kickout_threshold",
                     "required": true,
@@ -8676,34 +8763,12 @@
                     }
                   },
                   {
-                    "name": "num_block_producer_seats_per_shard",
-                    "required": true,
-                    "schema": {
-                      "type": "array",
-                      "description": "Defines number of shards and number of block producer seats per each shard at genesis.\nNote: not used with protocol_feature_chunk_only_producers -- replaced by minimum_validators_per_shard\nNote: not used before as all block producers produce chunks for all shards",
-                      "items": {
-                        "type": "integer",
-                        "format": "uint64"
-                      }
-                    }
-                  },
-                  {
                     "name": "num_blocks_per_year",
                     "required": true,
                     "schema": {
                       "type": "integer",
                       "description": "Expected number of blocks per year",
                       "format": "uint64"
-                    }
-                  },
-                  {
-                    "name": "num_chunk_only_producer_seats",
-                    "required": false,
-                    "schema": {
-                      "type": "integer",
-                      "description": "Deprecated.",
-                      "format": "uint64",
-                      "default": 300
                     }
                   },
                   {
@@ -8868,6 +8933,40 @@
                         "type": "object",
                         "description": "Account info for validators"
                       }
+                    }
+                  },
+                  {
+                    "name": "avg_hidden_validator_seats_per_shard",
+                    "required": false,
+                    "schema": {
+                      "type": "array",
+                      "description": "Expected number of hidden validators per shard.",
+                      "items": {
+                        "type": "integer",
+                        "format": "uint64"
+                      }
+                    }
+                  },
+                  {
+                    "name": "num_block_producer_seats_per_shard",
+                    "required": false,
+                    "schema": {
+                      "type": "array",
+                      "description": "Defines number of shards and number of block producer seats per each shard at genesis.\nNote: not used with protocol_feature_chunk_only_producers -- replaced by minimum_validators_per_shard\nNote: not used before as all block producers produce chunks for all shards",
+                      "items": {
+                        "type": "integer",
+                        "format": "uint64"
+                      }
+                    }
+                  },
+                  {
+                    "name": "num_chunk_only_producer_seats",
+                    "required": false,
+                    "schema": {
+                      "type": "integer",
+                      "description": "Deprecated.",
+                      "format": "uint64",
+                      "default": 300
                     }
                   }
                 ]
@@ -11818,14 +11917,14 @@
           }
         },
         {
-          "description": "Base64-encoded signed transaction. Generate a fresh signed payload for the signing account immediately before submission or status lookup.",
+          "description": "Base64-encoded Borsh serialization of a `SignedTransaction`; must be freshly signed (nonce above the access key's current value).",
           "label": "Signed Tx Base64",
           "location": "body",
           "name": "signed_tx_base64",
           "required": false,
           "schema": {
             "type": "string",
-            "description": "Base64-encoded signed transaction. Generate a fresh signed payload for the signing account immediately before submission or status lookup."
+            "description": "Base64-encoded Borsh serialization of a `SignedTransaction`; must be freshly signed (nonce above the access key's current value)."
           }
         },
         {
@@ -11946,7 +12045,7 @@
                   "required": false,
                   "schema": {
                     "type": "string",
-                    "description": "Base64-encoded signed transaction. Generate a fresh signed payload for the signing account immediately before submission or status lookup."
+                    "description": "Base64-encoded Borsh serialization of a `SignedTransaction`; must be freshly signed (nonce above the access key's current value)."
                   }
                 },
                 {
@@ -12188,7 +12287,7 @@
   {
     "canonicalPath": "/rpcs/transaction/broadcast_tx_async",
     "info": {
-      "description": "Submit a freshly signed transaction and immediately get its hash — no wait for execution. Default examples are illustrative only and are not reusable signed payloads.",
+      "description": "Broadcast a base64-encoded `SignedTransaction`; returns the transaction hash without awaiting inclusion or execution. Example payloads are placeholders and cannot be replayed.",
       "operationId": "broadcast_tx_async",
       "summary": "Send transaction asynchronously",
       "title": "NEAR Protocol RPC: Send transaction asynchronously",
@@ -12199,14 +12298,14 @@
       "defaultId": "fastnear",
       "fields": [
         {
-          "description": "Base64-encoded signed transaction. Generate a fresh signed payload for the signing account immediately before submission or status lookup.",
+          "description": "Base64-encoded signed transaction",
           "label": "Signed Tx Base64",
           "location": "body",
           "name": "signed_tx_base64",
           "required": true,
           "schema": {
             "type": "string",
-            "description": "Base64-encoded signed transaction. Generate a fresh signed payload for the signing account immediately before submission or status lookup."
+            "description": "Base64-encoded signed transaction"
           }
         },
         {
@@ -12307,7 +12406,7 @@
                   "required": true,
                   "schema": {
                     "type": "string",
-                    "description": "Base64-encoded signed transaction. Generate a fresh signed payload for the signing account immediately before submission or status lookup."
+                    "description": "Base64-encoded signed transaction"
                   }
                 },
                 {
@@ -12480,7 +12579,7 @@
   {
     "canonicalPath": "/rpcs/transaction/broadcast_tx_commit",
     "info": {
-      "description": "Submit a freshly signed transaction and wait for its commit — the legacy synchronous send, superseded by `send_tx`. Default examples are illustrative only and are not reusable signed payloads.",
+      "description": "Broadcast a base64-encoded `SignedTransaction`; blocks until execution completes or a 10-second timeout elapses. Deprecated — use `send_tx`. Example payloads are placeholders and cannot be replayed.",
       "operationId": "broadcast_tx_commit",
       "summary": "Send transaction and wait",
       "title": "NEAR Protocol RPC: Send transaction and wait",
@@ -12491,14 +12590,14 @@
       "defaultId": "fastnear",
       "fields": [
         {
-          "description": "Base64-encoded signed transaction. Generate a fresh signed payload for the signing account immediately before submission or status lookup.",
+          "description": "Base64-encoded signed transaction",
           "label": "Signed Tx Base64",
           "location": "body",
           "name": "signed_tx_base64",
           "required": true,
           "schema": {
             "type": "string",
-            "description": "Base64-encoded signed transaction. Generate a fresh signed payload for the signing account immediately before submission or status lookup."
+            "description": "Base64-encoded signed transaction"
           }
         },
         {
@@ -12599,7 +12698,7 @@
                   "required": true,
                   "schema": {
                     "type": "string",
-                    "description": "Base64-encoded signed transaction. Generate a fresh signed payload for the signing account immediately before submission or status lookup."
+                    "description": "Base64-encoded signed transaction"
                   }
                 },
                 {
@@ -12838,7 +12937,7 @@
   {
     "canonicalPath": "/rpcs/transaction/send_tx",
     "info": {
-      "description": "Submit a freshly signed transaction and wait for its final execution outcome — the current synchronous send. Default examples are illustrative only and are not reusable signed payloads.",
+      "description": "Broadcast a base64-encoded `SignedTransaction`; blocks until the execution outcome specified by `wait_until`. Example payloads are placeholders and cannot be replayed.",
       "operationId": "send_tx",
       "summary": "Send transaction",
       "title": "NEAR Protocol RPC: Send transaction",
@@ -12849,14 +12948,14 @@
       "defaultId": "fastnear",
       "fields": [
         {
-          "description": "Base64-encoded signed transaction. Generate a fresh signed payload for the signing account immediately before submission or status lookup.",
+          "description": "Base64-encoded signed transaction",
           "label": "Signed Tx Base64",
           "location": "body",
           "name": "signed_tx_base64",
           "required": true,
           "schema": {
             "type": "string",
-            "description": "Base64-encoded signed transaction. Generate a fresh signed payload for the signing account immediately before submission or status lookup."
+            "description": "Base64-encoded signed transaction"
           }
         },
         {
@@ -12959,7 +13058,7 @@
                   "required": true,
                   "schema": {
                     "type": "string",
-                    "description": "Base64-encoded signed transaction. Generate a fresh signed payload for the signing account immediately before submission or status lookup."
+                    "description": "Base64-encoded signed transaction"
                   }
                 },
                 {
@@ -13231,14 +13330,14 @@
           }
         },
         {
-          "description": "Base64-encoded signed transaction. Generate a fresh signed payload for the signing account immediately before submission or status lookup.",
+          "description": "Base64-encoded Borsh serialization of a `SignedTransaction`; must be freshly signed (nonce above the access key's current value).",
           "label": "Signed Tx Base64",
           "location": "body",
           "name": "signed_tx_base64",
           "required": false,
           "schema": {
             "type": "string",
-            "description": "Base64-encoded signed transaction. Generate a fresh signed payload for the signing account immediately before submission or status lookup."
+            "description": "Base64-encoded Borsh serialization of a `SignedTransaction`; must be freshly signed (nonce above the access key's current value)."
           }
         },
         {
@@ -13357,7 +13456,7 @@
                   "required": false,
                   "schema": {
                     "type": "string",
-                    "description": "Base64-encoded signed transaction. Generate a fresh signed payload for the signing account immediately before submission or status lookup."
+                    "description": "Base64-encoded Borsh serialization of a `SignedTransaction`; must be freshly signed (nonce above the access key's current value)."
                   }
                 },
                 {

--- a/src/data/generatedFastnearStructuredGraph.json
+++ b/src/data/generatedFastnearStructuredGraph.json
@@ -1208,14 +1208,14 @@
   "metadata": {
     "nearcoreSource": {
       "branch": "HEAD",
-      "commitSha": "72dbd0f789a427bed7e7552070b1828794f122b9",
+      "commitSha": "499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0",
       "dirty": true,
-      "generatedAt": "2026-04-17T13:39:55.482Z",
-      "releaseUrl": "https://github.com/near/nearcore/releases/tag/2.11.0",
+      "generatedAt": "2026-07-14T21:45:20.697Z",
+      "releaseUrl": "https://github.com/near/nearcore/releases/tag/2.13.0",
       "repoRoot": "../nearcore",
       "repoUrl": "https://github.com/near/nearcore",
       "specPath": "../nearcore/chain/jsonrpc/openapi/openapi.json",
-      "tag": "2.11.0",
+      "tag": "2.13.0",
       "tagSource": "exact"
     }
   },
@@ -3049,7 +3049,7 @@
     {
       "authSummary": "API key via query apiKey",
       "canonicalPath": "/rpcs/transaction/broadcast_tx_async",
-      "description": "Submit a freshly signed transaction and immediately get its hash — no wait for execution. Default examples are illustrative only and are not reusable signed payloads.",
+      "description": "Broadcast a base64-encoded `SignedTransaction`; returns the transaction hash without awaiting inclusion or execution. Example payloads are placeholders and cannot be replayed.",
       "docsPath": "/rpc/transaction/broadcast-tx-async",
       "familyId": "rpc-transaction",
       "headline": "NEAR Protocol RPC: Send transaction asynchronously",
@@ -3076,7 +3076,7 @@
     {
       "authSummary": "API key via query apiKey",
       "canonicalPath": "/rpcs/transaction/broadcast_tx_commit",
-      "description": "Submit a freshly signed transaction and wait for its commit — the legacy synchronous send, superseded by `send_tx`. Default examples are illustrative only and are not reusable signed payloads.",
+      "description": "Broadcast a base64-encoded `SignedTransaction`; blocks until execution completes or a 10-second timeout elapses. Deprecated — use `send_tx`. Example payloads are placeholders and cannot be replayed.",
       "docsPath": "/rpc/transaction/broadcast-tx-commit",
       "familyId": "rpc-transaction",
       "headline": "NEAR Protocol RPC: Send transaction and wait",
@@ -3157,7 +3157,7 @@
     {
       "authSummary": "API key via query apiKey",
       "canonicalPath": "/rpcs/transaction/send_tx",
-      "description": "Submit a freshly signed transaction and wait for its final execution outcome — the current synchronous send. Default examples are illustrative only and are not reusable signed payloads.",
+      "description": "Broadcast a base64-encoded `SignedTransaction`; blocks until the execution outcome specified by `wait_until`. Example payloads are placeholders and cannot be replayed.",
       "docsPath": "/rpc/transaction/send-tx",
       "familyId": "rpc-transaction",
       "headline": "NEAR Protocol RPC: Send transaction",


### PR DESCRIPTION
Brings the public RPC reference to **nearcore 2.13.0** and lands a **technical-register** pass over the affected descriptions.

**Supporting mike-docs PRs:** fastnear/docs-pipeline#5 (2.13.0 sync + field-description machinery) and fastnear/docs-pipeline#7 (recover + technicalize 7 RPC descriptions, tracks nearcore #16069).

## What changes on the docs
- **view_state** — new `after_key_base64` / `limit` / `last_key` pagination + `prefix_base64`, written as protocol reference ("Exclusive start cursor: returns only keys greater than this one…", "Maximum key/value entries per response (≥ 1)…")
- **view_access_key_list** — post-quantum (ML-DSA-65) access-key wording
- **client_config / genesis_config / EXPERIMENTAL_protocol_config** — 2.13.0 config-field updates
- **7 recovered RPC descriptions** — `call_function`, `tx_status`, `EXPERIMENTAL_tx_status`, `broadcast_tx_async` / `broadcast_tx_commit`, `send_tx`, tightened to protocol terms (`SignedTransaction`, Borsh/base64, `wait_until`, 10s timeout, deprecation)
- structured-graph `nearcoreSource` → nearcore **2.13.0**

## Vendored surgically
Only the **11 changed RPC page models** and `nearcoreSource` are updated. The richer REST schemas (neardata `BlockDocument`, etc.) and all other content on `main` are preserved untouched — mike-docs main is still catching up on those (see reconcile PR fastnear/docs-pipeline#6).
