### PR TITLE
docs(rpc): add EXPERIMENTAL_receipt_to_tx reference page

### DIFF
--- a/docs/rpc/transaction/experimental-receipt-to-tx.mdx
+++ b/docs/rpc/transaction/experimental-receipt-to-tx.mdx
@@ -1,0 +1,16 @@
+---
+title: Receipt to Transaction (Experimental)
+description: Resolve a receipt ID to its originating transaction on the NEAR blockchain
+slug: /rpc/transaction/experimental-receipt-to-tx
+sidebar_position: 8
+hide_table_of_contents: true
+---
+
+import FastnearDirectOperation from '@site/src/components/FastnearDirectOperation';
+
+# Receipt to Transaction (Experimental)
+
+`EXPERIMENTAL_receipt_to_tx` request type
+
+
+<FastnearDirectOperation pageModelId="rpc-EXPERIMENTAL-receipt-to-tx" renderDescription />

--- a/sidebars.js
+++ b/sidebars.js
@@ -154,6 +154,7 @@ const rpcSidebar = withExamplesFooter(
         'rpc/transaction/broadcast-tx-async',
         'rpc/transaction/broadcast-tx-commit',
         'rpc/transaction/experimental-receipt',
+        'rpc/transaction/experimental-receipt-to-tx',
         'rpc/transaction/experimental-tx-status',
       ],
     },

--- a/src/data/generatedFastnearPageModels.json
+++ b/src/data/generatedFastnearPageModels.json
@@ -11884,6 +11884,353 @@
     "sourceSpec": "rpcs/transaction/EXPERIMENTAL_receipt.yaml"
   },
   {
+    "canonicalPath": "/rpcs/transaction/EXPERIMENTAL_receipt_to_tx",
+    "info": {
+      "description": "Resolve a receipt ID to the transaction hash and signer that produced it. Requires a node with `save_receipt_to_tx` enabled; unindexed receipts return `UNKNOWN_RECEIPT`.",
+      "operationId": "EXPERIMENTAL_receipt_to_tx",
+      "summary": "Resolve receipt to transaction",
+      "title": "NEAR Protocol RPC: Resolve receipt to transaction",
+      "version": "1.0.0"
+    },
+    "interaction": {
+      "authTransport": "bearer",
+      "defaultId": "fastnear",
+      "fields": [
+        {
+          "description": "Optional hint: block height near where the receipt was created, to bound the fallback scan.",
+          "label": "Block Height",
+          "location": "body",
+          "name": "block_height",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Optional hint: block height near where the receipt was created, to bound the fallback scan.",
+            "format": "uint64"
+          }
+        },
+        {
+          "description": "Base58-encoded receipt ID to resolve to its originating transaction.",
+          "label": "Receipt Id",
+          "location": "body",
+          "name": "receipt_id",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "description": "Base58-encoded receipt ID to resolve to its originating transaction."
+          }
+        },
+        {
+          "description": "Optional hint: shard to scan at the hint height; omit to scan all tracked shards.",
+          "label": "Shard Id",
+          "location": "body",
+          "name": "shard_id",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Optional hint: shard to scan at the hint height; omit to scan all tracked shards."
+          }
+        },
+        {
+          "description": "Optional hint: ± block-height window scanned around the hint before walking ancestor blocks.",
+          "label": "Window",
+          "location": "body",
+          "name": "window",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Optional hint: ± block-height window scanned around the hint before walking ancestor blocks.",
+            "format": "uint64"
+          }
+        }
+      ],
+      "kind": "rpc-EXPERIMENTAL-receipt-to-tx",
+      "networks": [
+        {
+          "defaultFields": {
+            "receipt_id": "FcFKrKQziMPCgYMFiLMZwecBtA7vqxdkatkhc1j3GYj8"
+          },
+          "key": "mainnet",
+          "label": "Mainnet",
+          "url": "https://rpc.mainnet.fastnear.com"
+        },
+        {
+          "defaultFields": {
+            "receipt_id": "ExampleReceiptId",
+            "shard_id": 0
+          },
+          "key": "testnet",
+          "label": "Testnet",
+          "url": "https://rpc.testnet.fastnear.com"
+        }
+      ],
+      "requestMethod": "EXPERIMENTAL_receipt_to_tx",
+      "supportsFinality": false,
+      "transport": "json-rpc"
+    },
+    "pageModelId": "rpc-EXPERIMENTAL-receipt-to-tx",
+    "replaceOperationPage": true,
+    "request": {
+      "bodySchema": {
+        "type": "object",
+        "required": [
+          "jsonrpc",
+          "id",
+          "method",
+          "params"
+        ],
+        "properties": [
+          {
+            "name": "jsonrpc",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "2.0"
+              ]
+            }
+          },
+          {
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "fastnear"
+            }
+          },
+          {
+            "name": "method",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "EXPERIMENTAL_receipt_to_tx"
+              ]
+            }
+          },
+          {
+            "name": "params",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "required": [
+                "receipt_id"
+              ],
+              "properties": [
+                {
+                  "name": "block_height",
+                  "required": false,
+                  "schema": {
+                    "type": "integer",
+                    "nullable": true,
+                    "description": "Optional hint: block height near where the receipt was created, to bound the fallback scan.",
+                    "format": "uint64"
+                  }
+                },
+                {
+                  "name": "receipt_id",
+                  "required": true,
+                  "schema": {
+                    "type": "string",
+                    "description": "Base58-encoded receipt ID to resolve to its originating transaction."
+                  }
+                },
+                {
+                  "name": "shard_id",
+                  "required": false,
+                  "schema": {
+                    "type": "integer",
+                    "nullable": true,
+                    "description": "Optional hint: shard to scan at the hint height; omit to scan all tracked shards."
+                  }
+                },
+                {
+                  "name": "window",
+                  "required": false,
+                  "schema": {
+                    "type": "integer",
+                    "nullable": true,
+                    "description": "Optional hint: ± block-height window scanned around the hint before walking ancestor blocks.",
+                    "format": "uint64"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "examples": [
+        {
+          "id": "mainnet",
+          "label": "Resolve receipt to transaction (Mainnet)",
+          "network": "mainnet",
+          "request": {
+            "body": {
+              "jsonrpc": "2.0",
+              "id": "fastnear",
+              "method": "EXPERIMENTAL_receipt_to_tx",
+              "params": {
+                "receipt_id": "FcFKrKQziMPCgYMFiLMZwecBtA7vqxdkatkhc1j3GYj8"
+              }
+            },
+            "headers": {},
+            "path": {},
+            "query": {}
+          }
+        },
+        {
+          "id": "testnet",
+          "label": "Resolve receipt to transaction (Testnet)",
+          "network": "testnet",
+          "request": {
+            "body": {
+              "jsonrpc": "2.0",
+              "id": "fastnear",
+              "method": "EXPERIMENTAL_receipt_to_tx",
+              "params": {
+                "block_height": null,
+                "receipt_id": "ExampleReceiptId",
+                "shard_id": 0,
+                "window": null
+              }
+            },
+            "headers": {},
+            "path": {},
+            "query": {}
+          }
+        }
+      ],
+      "mediaType": "application/json",
+      "parameters": {
+        "header": [],
+        "path": [],
+        "query": []
+      },
+      "required": true
+    },
+    "responses": [
+      {
+        "description": "Successful response",
+        "mediaType": "application/json",
+        "schema": {
+          "type": "object",
+          "required": [
+            "jsonrpc",
+            "id"
+          ],
+          "properties": [
+            {
+              "name": "jsonrpc",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "enum": [
+                  "2.0"
+                ]
+              }
+            },
+            {
+              "name": "id",
+              "required": true,
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              }
+            },
+            {
+              "name": "result",
+              "required": false,
+              "schema": {
+                "type": "object",
+                "required": [
+                  "transaction_hash",
+                  "sender_account_id"
+                ],
+                "properties": [
+                  {
+                    "name": "sender_account_id",
+                    "required": true,
+                    "schema": {
+                      "type": "string",
+                      "description": "NEAR account ID"
+                    }
+                  },
+                  {
+                    "name": "transaction_hash",
+                    "required": true,
+                    "schema": {
+                      "type": "string",
+                      "description": "Base58-encoded hash"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "name": "error",
+              "required": false,
+              "schema": {
+                "type": "object",
+                "properties": [
+                  {
+                    "name": "code",
+                    "required": false,
+                    "schema": {
+                      "type": "integer"
+                    }
+                  },
+                  {
+                    "name": "message",
+                    "required": false,
+                    "schema": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "name": "data",
+                    "required": false,
+                    "schema": {
+                      "type": "object"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "refName": "JsonRpcResponse"
+        },
+        "status": "200"
+      }
+    ],
+    "route": {
+      "method": "POST",
+      "path": "/",
+      "transport": "json-rpc"
+    },
+    "routeAliases": [
+      "/rpcs/transaction/EXPERIMENTAL_receipt_to_tx/other/EXPERIMENTAL_receipt_to_tx",
+      "/reference/operation/EXPERIMENTAL_receipt_to_tx"
+    ],
+    "securitySchemes": [
+      {
+        "description": "The OpenAPI contract describes the FastNEAR API key as a query parameter named apiKey.",
+        "id": "ApiKeyAuth",
+        "in": "query",
+        "name": "apiKey",
+        "type": "apiKey"
+      }
+    ],
+    "sourceSpec": "rpcs/transaction/EXPERIMENTAL_receipt_to_tx.yaml"
+  },
+  {
     "canonicalPath": "/rpcs/transaction/EXPERIMENTAL_tx_status",
     "info": {
       "description": "Fetch a transaction's full receipt tree and per-receipt outcomes by Base58 hash — richer than `tx_status`.",

--- a/src/data/generatedFastnearStructuredGraph.json
+++ b/src/data/generatedFastnearStructuredGraph.json
@@ -1009,6 +1009,20 @@
       "pageModelId": "rpc-EXPERIMENTAL-receipt"
     },
     {
+      "canonicalPath": "/rpcs/transaction/EXPERIMENTAL_receipt_to_tx",
+      "items": [
+        {
+          "label": "Transaction RPC",
+          "path": "/rpc"
+        },
+        {
+          "label": "Resolve receipt to transaction",
+          "path": "/rpcs/transaction/EXPERIMENTAL_receipt_to_tx"
+        }
+      ],
+      "pageModelId": "rpc-EXPERIMENTAL-receipt-to-tx"
+    },
+    {
       "canonicalPath": "/rpcs/transaction/EXPERIMENTAL_tx_status",
       "items": [
         {
@@ -1210,7 +1224,7 @@
       "branch": "HEAD",
       "commitSha": "499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0",
       "dirty": true,
-      "generatedAt": "2026-07-14T21:45:20.697Z",
+      "generatedAt": "2026-07-15T15:19:36.945Z",
       "releaseUrl": "https://github.com/near/nearcore/releases/tag/2.13.0",
       "repoRoot": "../nearcore",
       "repoUrl": "https://github.com/near/nearcore",
@@ -3125,6 +3139,33 @@
       "schemaType": "APIReference",
       "sourceSpec": "rpcs/transaction/EXPERIMENTAL_receipt.yaml",
       "summary": "Get receipt by ID",
+      "transport": "json-rpc"
+    },
+    {
+      "authSummary": "API key via query apiKey",
+      "canonicalPath": "/rpcs/transaction/EXPERIMENTAL_receipt_to_tx",
+      "description": "Resolve a receipt ID to the transaction hash and signer that produced it. Requires a node with `save_receipt_to_tx` enabled; unindexed receipts return `UNKNOWN_RECEIPT`.",
+      "docsPath": "/rpc/transaction/experimental-receipt-to-tx",
+      "familyId": "rpc-transaction",
+      "headline": "NEAR Protocol RPC: Resolve receipt to transaction",
+      "httpMethod": "POST",
+      "id": "rpc-EXPERIMENTAL-receipt-to-tx",
+      "name": "NEAR Protocol RPC: Resolve receipt to transaction",
+      "networkKeys": [
+        "mainnet",
+        "testnet"
+      ],
+      "operationId": "EXPERIMENTAL_receipt_to_tx",
+      "pageModelId": "rpc-EXPERIMENTAL-receipt-to-tx",
+      "requestPath": "/",
+      "requestType": null,
+      "routeAliases": [
+        "/rpcs/transaction/EXPERIMENTAL_receipt_to_tx/other/EXPERIMENTAL_receipt_to_tx",
+        "/reference/operation/EXPERIMENTAL_receipt_to_tx"
+      ],
+      "schemaType": "APIReference",
+      "sourceSpec": "rpcs/transaction/EXPERIMENTAL_receipt_to_tx.yaml",
+      "summary": "Resolve receipt to transaction",
       "transport": "json-rpc"
     },
     {


### PR DESCRIPTION
New RPC reference page: **Receipt to Transaction (Experimental)** — resolves a receipt ID to the transaction that produced it (`EXPERIMENTAL_receipt_to_tx`, new in nearcore 2.13.0).

**Supporting mike-docs PR:** fastnear/docs-pipeline#8

- `docs/rpc/transaction/experimental-receipt-to-tx.mdx` + sidebar entry
- receipt_to_tx page model + structured-graph node (purely additive; +347/-0 on the page models, rich REST + everything else preserved)
