### PR TITLE
fix(rpc): show the real base endpoint in RPC response URL, not a fabr…

### DIFF
--- a/src/components/FastnearDirectOperation/index.js
+++ b/src/components/FastnearDirectOperation/index.js
@@ -547,33 +547,6 @@ function buildHttpExample(pageModel, example) {
   return `${pageModel.route.method} ${renderedPath}${renderedSearch}`;
 }
 
-function buildRpcEndpointUrl(pageModel, networkUrl) {
-  if (!networkUrl) {
-    return "";
-  }
-
-  let endpointPath = "";
-  if (typeof pageModel?.canonicalPath === "string" && pageModel.canonicalPath.startsWith("/rpcs/")) {
-    endpointPath = pageModel.canonicalPath.slice("/rpcs".length);
-  } else if (
-    typeof pageModel?.sourceSpec === "string" &&
-    pageModel.sourceSpec.startsWith("rpcs/") &&
-    pageModel.sourceSpec.endsWith(".yaml")
-  ) {
-    endpointPath = `/${pageModel.sourceSpec.slice("rpcs/".length, -".yaml".length)}`;
-  }
-
-  if (!endpointPath) {
-    endpointPath = pageModel?.route?.path || "/";
-  }
-
-  try {
-    return new URL(endpointPath, networkUrl).toString();
-  } catch (_error) {
-    return networkUrl;
-  }
-}
-
 function buildOperationExampleUrl(
   pageModel,
   currentHref,
@@ -1777,7 +1750,6 @@ function FastnearOperationPage({ pageModel }) {
           throw new Error(uiText.noRpcServer);
         }
 
-        const rpcEndpointUrl = buildRpcEndpointUrl(pageModel, selectedNetworkDetails.url);
         const headers = {
           Accept: "application/json",
           "Content-Type": "application/json",
@@ -1798,7 +1770,7 @@ function FastnearOperationPage({ pageModel }) {
             kind: "json",
             ok: response.ok,
             status: response.status,
-            url: rpcEndpointUrl || selectedNetworkDetails.url,
+            url: selectedNetworkDetails.url,
             value: JSON.parse(responseText),
           };
         } catch (_error) {
@@ -1806,7 +1778,7 @@ function FastnearOperationPage({ pageModel }) {
             kind: "text",
             ok: response.ok,
             status: response.status,
-            url: rpcEndpointUrl || selectedNetworkDetails.url,
+            url: selectedNetworkDetails.url,
             value: responseText,
           };
         }

--- a/tests/playwright/rpc-operations.spec.js
+++ b/tests/playwright/rpc-operations.spec.js
@@ -149,13 +149,13 @@ test('live and expanded responses show the RPC endpoint URL', async ({ page }) =
   await requestPromise;
 
   const inlineRequestTarget = page.locator('.fastnear-interaction__result-url').first();
-  await expect(inlineRequestTarget).toHaveText('https://rpc.mainnet.fastnear.com/account/view_account');
+  await expect(inlineRequestTarget).toHaveText('https://rpc.mainnet.fastnear.com');
 
   await page.getByRole('button', { name: 'Expand response' }).click();
   const expandedRequestTarget = page
     .getByRole('dialog', { name: 'Expanded response' })
     .locator('.fastnear-interaction__result-url');
-  await expect(expandedRequestTarget).toHaveText('https://rpc.mainnet.fastnear.com/account/view_account');
+  await expect(expandedRequestTarget).toHaveText('https://rpc.mainnet.fastnear.com');
 });
 
 test('expanded response modal supports find, next, previous, and keyboard navigation', async ({ page }) => {


### PR DESCRIPTION
…icated path

The LIVE RESPONSE header and the expanded-response modal on RPC operation pages displayed a synthetic URL like
`https://rpc.mainnet.fastnear.com/account/view_account`. NEAR JSON-RPC does not route by path — every method is a POST to the base endpoint with the method in the JSON body — so that `/account/view_account` slug never matched the actual request that the page fires.

Drop the buildRpcEndpointUrl helper (which derived the slug from the canonical docs path) and report the real endpoint the request POSTs to (selectedNetworkDetails.url), which also correctly tracks mainnet/testnet. The change is runtime-display only; REST/HTTP pages, which have genuine paths, are untouched.

Update the two playwright assertions that had codified the old behavior.


Claude-Session: https://claude.ai/code/session_01H8DjaLbA7Ed63XuSAENrJ7