### PR TITLE
fix(rpc): make live RPC examples evergreen (74/80 pass, was 41)

### DIFF
--- a/src/data/generatedFastnearPageModels.json
+++ b/src/data/generatedFastnearPageModels.json
@@ -4159,15 +4159,16 @@
           }
         },
         {
-          "description": "Proof subject — `receipt` proves inclusion of a specific receipt produced during execution.",
+          "description": "Proof subject — `transaction` proves inclusion of the top-level transaction, `receipt` proves inclusion of a specific receipt produced during execution.",
           "label": "Type",
           "location": "body",
           "name": "type",
           "required": false,
           "schema": {
             "type": "string",
-            "description": "Proof subject — `receipt` proves inclusion of a specific receipt produced during execution.",
+            "description": "Proof subject — `transaction` proves inclusion of the top-level transaction, `receipt` proves inclusion of a specific receipt produced during execution.",
             "enum": [
+              "transaction",
               "receipt"
             ]
           }
@@ -4302,8 +4303,9 @@
                   "required": false,
                   "schema": {
                     "type": "string",
-                    "description": "Proof subject — `receipt` proves inclusion of a specific receipt produced during execution.",
+                    "description": "Proof subject — `transaction` proves inclusion of the top-level transaction, `receipt` proves inclusion of a specific receipt produced during execution.",
                     "enum": [
+                      "transaction",
                       "receipt"
                     ]
                   }
@@ -9550,15 +9552,16 @@
           }
         },
         {
-          "description": "Proof subject — `receipt` proves inclusion of a specific receipt produced during execution.",
+          "description": "Proof subject — `transaction` proves inclusion of the top-level transaction, `receipt` proves inclusion of a specific receipt produced during execution.",
           "label": "Type",
           "location": "body",
           "name": "type",
           "required": false,
           "schema": {
             "type": "string",
-            "description": "Proof subject — `receipt` proves inclusion of a specific receipt produced during execution.",
+            "description": "Proof subject — `transaction` proves inclusion of the top-level transaction, `receipt` proves inclusion of a specific receipt produced during execution.",
             "enum": [
+              "transaction",
               "receipt"
             ]
           }
@@ -9693,8 +9696,9 @@
                   "required": false,
                   "schema": {
                     "type": "string",
-                    "description": "Proof subject — `receipt` proves inclusion of a specific receipt produced during execution.",
+                    "description": "Proof subject — `transaction` proves inclusion of the top-level transaction, `receipt` proves inclusion of a specific receipt produced during execution.",
                     "enum": [
+                      "transaction",
                       "receipt"
                     ]
                   }

--- a/src/data/generatedFastnearPageModels.json
+++ b/src/data/generatedFastnearPageModels.json
@@ -12676,7 +12676,7 @@
       "networks": [
         {
           "defaultFields": {
-            "signed_tx_base64": "DgAAAG1pa2UubmVhcgCpPJgEEFUwQjFQvL8V3CnZ0h688WG5sVsKE8JYM37ax2cUjgEAAAAAAAAADQAAAG1pa2V0ZXN0Lm5lYXIPfFBmYNAIe2/MicVhDXbvT3w06LxS2OCF0UHIYgjNDQAAAHRlc3RpbmcgbWVtbwEAAAADAQAAAAAAAAAAAAAAAAAAAA=="
+            "signed_tx_base64": "CQAAAG1pa2UubmVhcgCCy5RvHN/3t5Oejtf0aWKCCwJIxXkWWCQKxnaU9nr4nAEAAAAAAAAADQAAAG1pa2V0ZXN0Lm5lYXL6UXoKlIC/UXiHRkiBCYVW69w6N/+7ZXy0+gPAs9TQ5wEAAAADAQAAAAAAAAAAAAAAAAAAAABv/f+CgT7byEQUzraUd1LDQ7ELv5ld7bhFGUYNaxWWRMzl5rAuRhcfkV2jHIqJgu0sfw7B9/npIH69aqsm/GIM"
           },
           "key": "mainnet",
           "label": "Mainnet",
@@ -12684,7 +12684,7 @@
         },
         {
           "defaultFields": {
-            "signed_tx_base64": "DgAAAG1pa2UudGVzdG5ldACpPJgEEFUwQjFQvL8V3CnZ0h688WG5sVsKE8JYM37ax2cUjgEAAAAAAAAADQAAAG1pa2V0ZXN0LnRlc3RuZXQPfFBmYNAIe2/MicVhDXbvT3w06LxS2OCF0UHIYgjNDQAAAHRlc3RpbmcgbWVtbwEAAAADAQAAAAAAAAAAAAAAAAAAAA=="
+            "signed_tx_base64": "DAAAAG1pa2UudGVzdG5ldAD7f6gOSLbFPadEDmehA6rmcy+EOXYRGly1GK0ponIwDgEAAAAAAAAAEAAAAG1pa2V0ZXN0LnRlc3RuZXTmqC62j/JHfs1+RJFA5+kaPJY8rDAfhHuh2G548XJ6GQEAAAADAQAAAAAAAAAAAAAAAAAAAADq6qRsj8FW73GukqS5yqwXYL7riy7EcIaZrhZy40hMq4Kux+lp+AsMLtVPqic5xAfX5dlLaFRJ6Nbi2Th185UI"
           },
           "key": "testnet",
           "label": "Testnet",
@@ -12785,7 +12785,7 @@
               "id": "fastnear",
               "method": "broadcast_tx_async",
               "params": {
-                "signed_tx_base64": "DgAAAG1pa2UubmVhcgCpPJgEEFUwQjFQvL8V3CnZ0h688WG5sVsKE8JYM37ax2cUjgEAAAAAAAAADQAAAG1pa2V0ZXN0Lm5lYXIPfFBmYNAIe2/MicVhDXbvT3w06LxS2OCF0UHIYgjNDQAAAHRlc3RpbmcgbWVtbwEAAAADAQAAAAAAAAAAAAAAAAAAAA=="
+                "signed_tx_base64": "CQAAAG1pa2UubmVhcgCCy5RvHN/3t5Oejtf0aWKCCwJIxXkWWCQKxnaU9nr4nAEAAAAAAAAADQAAAG1pa2V0ZXN0Lm5lYXL6UXoKlIC/UXiHRkiBCYVW69w6N/+7ZXy0+gPAs9TQ5wEAAAADAQAAAAAAAAAAAAAAAAAAAABv/f+CgT7byEQUzraUd1LDQ7ELv5ld7bhFGUYNaxWWRMzl5rAuRhcfkV2jHIqJgu0sfw7B9/npIH69aqsm/GIM"
               }
             },
             "headers": {},
@@ -12803,7 +12803,7 @@
               "id": "fastnear",
               "method": "broadcast_tx_async",
               "params": {
-                "signed_tx_base64": "DgAAAG1pa2UudGVzdG5ldACpPJgEEFUwQjFQvL8V3CnZ0h688WG5sVsKE8JYM37ax2cUjgEAAAAAAAAADQAAAG1pa2V0ZXN0LnRlc3RuZXQPfFBmYNAIe2/MicVhDXbvT3w06LxS2OCF0UHIYgjNDQAAAHRlc3RpbmcgbWVtbwEAAAADAQAAAAAAAAAAAAAAAAAAAA=="
+                "signed_tx_base64": "DAAAAG1pa2UudGVzdG5ldAD7f6gOSLbFPadEDmehA6rmcy+EOXYRGly1GK0ponIwDgEAAAAAAAAAEAAAAG1pa2V0ZXN0LnRlc3RuZXTmqC62j/JHfs1+RJFA5+kaPJY8rDAfhHuh2G548XJ6GQEAAAADAQAAAAAAAAAAAAAAAAAAAADq6qRsj8FW73GukqS5yqwXYL7riy7EcIaZrhZy40hMq4Kux+lp+AsMLtVPqic5xAfX5dlLaFRJ6Nbi2Th185UI"
               }
             },
             "headers": {},
@@ -12968,7 +12968,7 @@
       "networks": [
         {
           "defaultFields": {
-            "signed_tx_base64": "DgAAAG1pa2UubmVhcgCpPJgEEFUwQjFQvL8V3CnZ0h688WG5sVsKE8JYM37ax2cUjgEAAAAAAAAADQAAAG1pa2V0ZXN0Lm5lYXIPfFBmYNAIe2/MicVhDXbvT3w06LxS2OCF0UHIYgjNDQAAAHRlc3RpbmcgbWVtbwEAAAADAQAAAAAAAAAAAAAAAAAAAA=="
+            "signed_tx_base64": "CQAAAG1pa2UubmVhcgD64cHVt7yB8HSzql1e8RLKSv2riwv7+vNviWHD/y95EgEAAAAAAAAADQAAAG1pa2V0ZXN0Lm5lYXJBM1Y72BJnk/V7dlrTRBxxxUxyB/JXo+hODCyF0woAEAEAAAADAQAAAAAAAAAAAAAAAAAAAADiGG3IJC5QsOBN70h+glB+U9nBYEXObdaPHMjXyu2YQbQUvALIWbdBBxhuR9VQ/fEXg7L0vGSCd9wCCrq0CFIF"
           },
           "key": "mainnet",
           "label": "Mainnet",
@@ -12976,7 +12976,7 @@
         },
         {
           "defaultFields": {
-            "signed_tx_base64": "DgAAAG1pa2UudGVzdG5ldACpPJgEEFUwQjFQvL8V3CnZ0h688WG5sVsKE8JYM37ax2cUjgEAAAAAAAAADQAAAG1pa2V0ZXN0LnRlc3RuZXQPfFBmYNAIe2/MicVhDXbvT3w06LxS2OCF0UHIYgjNDQAAAHRlc3RpbmcgbWVtbwEAAAADAQAAAAAAAAAAAAAAAAAAAA=="
+            "signed_tx_base64": "DAAAAG1pa2UudGVzdG5ldAAnrCNE2/YvBtldmNpxP3k7ego/A6RxrtUvzhp3ngJJTQEAAAAAAAAAEAAAAG1pa2V0ZXN0LnRlc3RuZXTIRL9kr4DAnxTBWcN/e5852wyOE353mPf+XnCN73Z/hwEAAAADAQAAAAAAAAAAAAAAAAAAAADMWuZ8agklUGXpr759mp4DIsPFKgc+ZYFMjR6hjoPrNR9vPxFeLVm8jpLqr6+U9BnlQU7chIfUkeppU1YFvHsO"
           },
           "key": "testnet",
           "label": "Testnet",
@@ -13077,7 +13077,7 @@
               "id": "fastnear",
               "method": "broadcast_tx_commit",
               "params": {
-                "signed_tx_base64": "DgAAAG1pa2UubmVhcgCpPJgEEFUwQjFQvL8V3CnZ0h688WG5sVsKE8JYM37ax2cUjgEAAAAAAAAADQAAAG1pa2V0ZXN0Lm5lYXIPfFBmYNAIe2/MicVhDXbvT3w06LxS2OCF0UHIYgjNDQAAAHRlc3RpbmcgbWVtbwEAAAADAQAAAAAAAAAAAAAAAAAAAA=="
+                "signed_tx_base64": "CQAAAG1pa2UubmVhcgD64cHVt7yB8HSzql1e8RLKSv2riwv7+vNviWHD/y95EgEAAAAAAAAADQAAAG1pa2V0ZXN0Lm5lYXJBM1Y72BJnk/V7dlrTRBxxxUxyB/JXo+hODCyF0woAEAEAAAADAQAAAAAAAAAAAAAAAAAAAADiGG3IJC5QsOBN70h+glB+U9nBYEXObdaPHMjXyu2YQbQUvALIWbdBBxhuR9VQ/fEXg7L0vGSCd9wCCrq0CFIF"
               }
             },
             "headers": {},
@@ -13095,7 +13095,7 @@
               "id": "fastnear",
               "method": "broadcast_tx_commit",
               "params": {
-                "signed_tx_base64": "DgAAAG1pa2UudGVzdG5ldACpPJgEEFUwQjFQvL8V3CnZ0h688WG5sVsKE8JYM37ax2cUjgEAAAAAAAAADQAAAG1pa2V0ZXN0LnRlc3RuZXQPfFBmYNAIe2/MicVhDXbvT3w06LxS2OCF0UHIYgjNDQAAAHRlc3RpbmcgbWVtbwEAAAADAQAAAAAAAAAAAAAAAAAAAA=="
+                "signed_tx_base64": "DAAAAG1pa2UudGVzdG5ldAAnrCNE2/YvBtldmNpxP3k7ego/A6RxrtUvzhp3ngJJTQEAAAAAAAAAEAAAAG1pa2V0ZXN0LnRlc3RuZXTIRL9kr4DAnxTBWcN/e5852wyOE353mPf+XnCN73Z/hwEAAAADAQAAAAAAAAAAAAAAAAAAAADMWuZ8agklUGXpr759mp4DIsPFKgc+ZYFMjR6hjoPrNR9vPxFeLVm8jpLqr6+U9BnlQU7chIfUkeppU1YFvHsO"
               }
             },
             "headers": {},

--- a/src/data/generatedFastnearPageModels.json
+++ b/src/data/generatedFastnearPageModels.json
@@ -13326,7 +13326,7 @@
       "networks": [
         {
           "defaultFields": {
-            "signed_tx_base64": "ExampleBase64EncodedTransaction",
+            "signed_tx_base64": "CQAAAG1pa2UubmVhcgBPiSiO5F7KYuZ9VQ2eF6/b9dXqrBUBxDs2AuXiQZw8DgEAAAAAAAAADQAAAG1pa2V0ZXN0Lm5lYXKwzpn8eLLqwzoVC5PlcvpzSXj65ke9WN3TLsRpndusbgEAAAADAQAAAAAAAAAAAAAAAAAAAAC7RkXLWjBx/qplpt/RT2uwQWvrovT3+6ef0BG1LU5OahlAsFmjEsuOv8rg4JI8TXOkg16oXljReiM4KU41yHYM",
             "wait_until": "EXECUTED_OPTIMISTIC"
           },
           "key": "mainnet",
@@ -13335,7 +13335,7 @@
         },
         {
           "defaultFields": {
-            "signed_tx_base64": "ExampleBase64EncodedTransaction",
+            "signed_tx_base64": "DAAAAG1pa2UudGVzdG5ldABpWDhNQVV7BkV62S5Hbdm5jBNjKhV1eGJAHSwC6iwNqgEAAAAAAAAAEAAAAG1pa2V0ZXN0LnRlc3RuZXQlxP80whXgLsNL4raSbYLM3YKFSTxZTp6FZcg8ExwGpwEAAAADAQAAAAAAAAAAAAAAAAAAAADLrZ/qNwNTZoXF4ALlKxLeC0nfTZol2HyyY0XoChnSNATaQ27bP5HM90mAhgq4OI7Zo+k3GQ1CxC3bGUqbhMcD",
             "wait_until": "EXECUTED_OPTIMISTIC"
           },
           "key": "testnet",
@@ -13437,7 +13437,7 @@
               "id": "fastnear",
               "method": "send_tx",
               "params": {
-                "signed_tx_base64": "ExampleBase64EncodedTransaction",
+                "signed_tx_base64": "CQAAAG1pa2UubmVhcgBPiSiO5F7KYuZ9VQ2eF6/b9dXqrBUBxDs2AuXiQZw8DgEAAAAAAAAADQAAAG1pa2V0ZXN0Lm5lYXKwzpn8eLLqwzoVC5PlcvpzSXj65ke9WN3TLsRpndusbgEAAAADAQAAAAAAAAAAAAAAAAAAAAC7RkXLWjBx/qplpt/RT2uwQWvrovT3+6ef0BG1LU5OahlAsFmjEsuOv8rg4JI8TXOkg16oXljReiM4KU41yHYM",
                 "wait_until": "EXECUTED_OPTIMISTIC"
               }
             },
@@ -13456,7 +13456,7 @@
               "id": "fastnear",
               "method": "send_tx",
               "params": {
-                "signed_tx_base64": "ExampleBase64EncodedTransaction",
+                "signed_tx_base64": "DAAAAG1pa2UudGVzdG5ldABpWDhNQVV7BkV62S5Hbdm5jBNjKhV1eGJAHSwC6iwNqgEAAAAAAAAAEAAAAG1pa2V0ZXN0LnRlc3RuZXQlxP80whXgLsNL4raSbYLM3YKFSTxZTp6FZcg8ExwGpwEAAAADAQAAAAAAAAAAAAAAAAAAAADLrZ/qNwNTZoXF4ALlKxLeC0nfTZol2HyyY0XoChnSNATaQ27bP5HM90mAhgq4OI7Zo+k3GQ1CxC3bGUqbhMcD",
                 "wait_until": "EXECUTED_OPTIMISTIC"
               }
             },

--- a/src/data/generatedFastnearPageModels.json
+++ b/src/data/generatedFastnearPageModels.json
@@ -1017,7 +1017,7 @@
           },
           "key": "mainnet",
           "label": "Mainnet",
-          "url": "https://rpc.mainnet.fastnear.com"
+          "url": "https://archival-rpc.mainnet.fastnear.com"
         },
         {
           "defaultFields": {
@@ -1025,7 +1025,7 @@
           },
           "key": "testnet",
           "label": "Testnet",
-          "url": "https://rpc.testnet.fastnear.com"
+          "url": "https://archival-rpc.testnet.fastnear.com"
         }
       ],
       "requestMethod": "block",
@@ -1271,7 +1271,7 @@
           },
           "key": "mainnet",
           "label": "Mainnet",
-          "url": "https://rpc.mainnet.fastnear.com"
+          "url": "https://archival-rpc.mainnet.fastnear.com"
         },
         {
           "defaultFields": {
@@ -1279,7 +1279,7 @@
           },
           "key": "testnet",
           "label": "Testnet",
-          "url": "https://rpc.testnet.fastnear.com"
+          "url": "https://archival-rpc.testnet.fastnear.com"
         }
       ],
       "requestMethod": "block",
@@ -1529,17 +1529,13 @@
       "kind": "rpc-block-effects",
       "networks": [
         {
-          "defaultFields": {
-            "block_id": 9820210
-          },
+          "defaultFields": {},
           "key": "mainnet",
           "label": "Mainnet",
           "url": "https://rpc.mainnet.fastnear.com"
         },
         {
-          "defaultFields": {
-            "block_id": 245254793
-          },
+          "defaultFields": {},
           "key": "testnet",
           "label": "Testnet",
           "url": "https://rpc.testnet.fastnear.com"
@@ -1631,7 +1627,7 @@
               "id": "fastnear",
               "method": "block_effects",
               "params": {
-                "block_id": 9820210
+                "finality": "final"
               }
             },
             "headers": {},
@@ -1649,7 +1645,7 @@
               "id": "fastnear",
               "method": "block_effects",
               "params": {
-                "block_id": 245254793
+                "finality": "final"
               }
             },
             "headers": {},
@@ -3152,8 +3148,8 @@
         },
         {
           "defaultFields": {
-            "account_id": "v1.signer-prod.testnet",
-            "prefix_base64": "U1RBVEU="
+            "account_id": "counter.testnet",
+            "prefix_base64": ""
           },
           "key": "testnet",
           "label": "Testnet",
@@ -3322,8 +3318,8 @@
               "params": {
                 "request_type": "view_state",
                 "finality": "final",
-                "account_id": "v1.signer-prod.testnet",
-                "prefix_base64": "U1RBVEU="
+                "account_id": "counter.testnet",
+                "prefix_base64": ""
               }
             },
             "headers": {},
@@ -3528,7 +3524,7 @@
           },
           "key": "mainnet",
           "label": "Mainnet",
-          "url": "https://rpc.mainnet.fastnear.com"
+          "url": "https://archival-rpc.mainnet.fastnear.com"
         },
         {
           "defaultFields": {
@@ -3537,7 +3533,7 @@
           },
           "key": "testnet",
           "label": "Testnet",
-          "url": "https://rpc.testnet.fastnear.com"
+          "url": "https://archival-rpc.testnet.fastnear.com"
         }
       ],
       "requestMethod": "EXPERIMENTAL_congestion_level",
@@ -3829,7 +3825,7 @@
           },
           "key": "mainnet",
           "label": "Mainnet",
-          "url": "https://rpc.mainnet.fastnear.com"
+          "url": "https://archival-rpc.mainnet.fastnear.com"
         },
         {
           "defaultFields": {
@@ -3838,7 +3834,7 @@
           },
           "key": "testnet",
           "label": "Testnet",
-          "url": "https://rpc.testnet.fastnear.com"
+          "url": "https://archival-rpc.testnet.fastnear.com"
         }
       ],
       "requestMethod": "EXPERIMENTAL_light_client_block_proof",
@@ -4206,22 +4202,22 @@
             "light_client_head": "9XN7MtDywZvfGx6TKy1MT2iCZkKuHikJXmNazxdZ4x6T",
             "sender_id": "escrow.ai.near",
             "transaction_hash": "34E7weKCDqXh3xPKdBgSWRqo44yTWjbka9deMK8JbAxx",
-            "type": "receipt"
+            "type": "transaction"
           },
           "key": "mainnet",
           "label": "Mainnet",
-          "url": "https://rpc.mainnet.fastnear.com"
+          "url": "https://archival-rpc.mainnet.fastnear.com"
         },
         {
           "defaultFields": {
             "light_client_head": "6JYj6i1FaUCzdoqy41CqUcZJxa5n9EmLEENRDH2gLm5u",
             "sender_id": "near-mpc-staking4all-01.testnet",
             "transaction_hash": "9LPbkwJ26HYgda7KHrURc6jozBcpdA1kUMSEzwm81JPx",
-            "type": "receipt"
+            "type": "transaction"
           },
           "key": "testnet",
           "label": "Testnet",
-          "url": "https://rpc.testnet.fastnear.com"
+          "url": "https://archival-rpc.testnet.fastnear.com"
         }
       ],
       "requestMethod": "EXPERIMENTAL_light_client_proof",
@@ -4347,7 +4343,7 @@
                 "light_client_head": "9XN7MtDywZvfGx6TKy1MT2iCZkKuHikJXmNazxdZ4x6T",
                 "sender_id": "escrow.ai.near",
                 "transaction_hash": "34E7weKCDqXh3xPKdBgSWRqo44yTWjbka9deMK8JbAxx",
-                "type": "receipt"
+                "type": "transaction"
               }
             },
             "headers": {},
@@ -4368,7 +4364,7 @@
                 "light_client_head": "6JYj6i1FaUCzdoqy41CqUcZJxa5n9EmLEENRDH2gLm5u",
                 "sender_id": "near-mpc-staking4all-01.testnet",
                 "transaction_hash": "9LPbkwJ26HYgda7KHrURc6jozBcpdA1kUMSEzwm81JPx",
-                "type": "receipt"
+                "type": "transaction"
               }
             },
             "headers": {},
@@ -5793,7 +5789,7 @@
           },
           "key": "mainnet",
           "label": "Mainnet",
-          "url": "https://rpc.mainnet.fastnear.com"
+          "url": "https://archival-rpc.mainnet.fastnear.com"
         },
         {
           "defaultFields": {
@@ -5802,7 +5798,7 @@
           },
           "key": "testnet",
           "label": "Testnet",
-          "url": "https://rpc.testnet.fastnear.com"
+          "url": "https://archival-rpc.testnet.fastnear.com"
         }
       ],
       "requestMethod": "chunk",
@@ -6298,7 +6294,7 @@
           },
           "key": "mainnet",
           "label": "Mainnet",
-          "url": "https://rpc.mainnet.fastnear.com"
+          "url": "https://archival-rpc.mainnet.fastnear.com"
         },
         {
           "defaultFields": {
@@ -6306,7 +6302,7 @@
           },
           "key": "testnet",
           "label": "Testnet",
-          "url": "https://rpc.testnet.fastnear.com"
+          "url": "https://archival-rpc.testnet.fastnear.com"
         }
       ],
       "requestMethod": "chunk",
@@ -8142,7 +8138,7 @@
           },
           "key": "mainnet",
           "label": "Mainnet",
-          "url": "https://rpc.mainnet.fastnear.com"
+          "url": "https://archival-rpc.mainnet.fastnear.com"
         },
         {
           "defaultFields": {
@@ -8150,7 +8146,7 @@
           },
           "key": "testnet",
           "label": "Testnet",
-          "url": "https://rpc.testnet.fastnear.com"
+          "url": "https://archival-rpc.testnet.fastnear.com"
         }
       ],
       "requestMethod": "gas_price",
@@ -9597,22 +9593,22 @@
             "light_client_head": "9XN7MtDywZvfGx6TKy1MT2iCZkKuHikJXmNazxdZ4x6T",
             "sender_id": "escrow.ai.near",
             "transaction_hash": "34E7weKCDqXh3xPKdBgSWRqo44yTWjbka9deMK8JbAxx",
-            "type": "receipt"
+            "type": "transaction"
           },
           "key": "mainnet",
           "label": "Mainnet",
-          "url": "https://rpc.mainnet.fastnear.com"
+          "url": "https://archival-rpc.mainnet.fastnear.com"
         },
         {
           "defaultFields": {
             "light_client_head": "6JYj6i1FaUCzdoqy41CqUcZJxa5n9EmLEENRDH2gLm5u",
             "sender_id": "near-mpc-staking4all-01.testnet",
             "transaction_hash": "9LPbkwJ26HYgda7KHrURc6jozBcpdA1kUMSEzwm81JPx",
-            "type": "receipt"
+            "type": "transaction"
           },
           "key": "testnet",
           "label": "Testnet",
-          "url": "https://rpc.testnet.fastnear.com"
+          "url": "https://archival-rpc.testnet.fastnear.com"
         }
       ],
       "requestMethod": "light_client_proof",
@@ -9735,7 +9731,7 @@
               "id": "fastnear",
               "method": "light_client_proof",
               "params": {
-                "type": "receipt",
+                "type": "transaction",
                 "transaction_hash": "34E7weKCDqXh3xPKdBgSWRqo44yTWjbka9deMK8JbAxx",
                 "sender_id": "escrow.ai.near",
                 "light_client_head": "9XN7MtDywZvfGx6TKy1MT2iCZkKuHikJXmNazxdZ4x6T"
@@ -9756,7 +9752,7 @@
               "id": "fastnear",
               "method": "light_client_proof",
               "params": {
-                "type": "receipt",
+                "type": "transaction",
                 "transaction_hash": "9LPbkwJ26HYgda7KHrURc6jozBcpdA1kUMSEzwm81JPx",
                 "sender_id": "near-mpc-staking4all-01.testnet",
                 "light_client_head": "6JYj6i1FaUCzdoqy41CqUcZJxa5n9EmLEENRDH2gLm5u"
@@ -10672,7 +10668,7 @@
           },
           "key": "mainnet",
           "label": "Mainnet",
-          "url": "https://rpc.mainnet.fastnear.com"
+          "url": "https://archival-rpc.mainnet.fastnear.com"
         },
         {
           "defaultFields": {
@@ -10680,7 +10676,7 @@
           },
           "key": "testnet",
           "label": "Testnet",
-          "url": "https://rpc.testnet.fastnear.com"
+          "url": "https://archival-rpc.testnet.fastnear.com"
         }
       ],
       "requestMethod": "next_light_client_block",
@@ -11612,7 +11608,7 @@
           },
           "key": "mainnet",
           "label": "Mainnet",
-          "url": "https://rpc.mainnet.fastnear.com"
+          "url": "https://archival-rpc.mainnet.fastnear.com"
         },
         {
           "defaultFields": {
@@ -11620,7 +11616,7 @@
           },
           "key": "testnet",
           "label": "Testnet",
-          "url": "https://rpc.testnet.fastnear.com"
+          "url": "https://archival-rpc.testnet.fastnear.com"
         }
       ],
       "requestMethod": "EXPERIMENTAL_receipt",
@@ -11950,20 +11946,21 @@
       "networks": [
         {
           "defaultFields": {
-            "receipt_id": "FcFKrKQziMPCgYMFiLMZwecBtA7vqxdkatkhc1j3GYj8"
+            "block_height": 194263442,
+            "receipt_id": "ETMK9HmPsAYcNxfSXBejMWQs57W4Ph5HDYoYhDMpotQn"
           },
           "key": "mainnet",
           "label": "Mainnet",
-          "url": "https://rpc.mainnet.fastnear.com"
+          "url": "https://archival-rpc.mainnet.fastnear.com"
         },
         {
           "defaultFields": {
-            "receipt_id": "ExampleReceiptId",
-            "shard_id": 0
+            "block_height": 246016180,
+            "receipt_id": "9uJmhNCLRgsFncH3anffPLE1YsZCPTyAZrBdekc3vTaZ"
           },
           "key": "testnet",
           "label": "Testnet",
-          "url": "https://rpc.testnet.fastnear.com"
+          "url": "https://archival-rpc.testnet.fastnear.com"
         }
       ],
       "requestMethod": "EXPERIMENTAL_receipt_to_tx",
@@ -12072,7 +12069,8 @@
               "id": "fastnear",
               "method": "EXPERIMENTAL_receipt_to_tx",
               "params": {
-                "receipt_id": "FcFKrKQziMPCgYMFiLMZwecBtA7vqxdkatkhc1j3GYj8"
+                "receipt_id": "ETMK9HmPsAYcNxfSXBejMWQs57W4Ph5HDYoYhDMpotQn",
+                "block_height": 194263442
               }
             },
             "headers": {},
@@ -12090,10 +12088,8 @@
               "id": "fastnear",
               "method": "EXPERIMENTAL_receipt_to_tx",
               "params": {
-                "block_height": null,
-                "receipt_id": "ExampleReceiptId",
-                "shard_id": 0,
-                "window": null
+                "receipt_id": "9uJmhNCLRgsFncH3anffPLE1YsZCPTyAZrBdekc3vTaZ",
+                "block_height": 246016180
               }
             },
             "headers": {},
@@ -12307,7 +12303,7 @@
           },
           "key": "mainnet",
           "label": "Mainnet",
-          "url": "https://rpc.mainnet.fastnear.com"
+          "url": "https://archival-rpc.mainnet.fastnear.com"
         },
         {
           "defaultFields": {
@@ -12317,7 +12313,7 @@
           },
           "key": "testnet",
           "label": "Testnet",
-          "url": "https://rpc.testnet.fastnear.com"
+          "url": "https://archival-rpc.testnet.fastnear.com"
         }
       ],
       "requestMethod": "EXPERIMENTAL_tx_status",
@@ -13719,7 +13715,7 @@
           },
           "key": "mainnet",
           "label": "Mainnet",
-          "url": "https://rpc.mainnet.fastnear.com"
+          "url": "https://archival-rpc.mainnet.fastnear.com"
         },
         {
           "defaultFields": {
@@ -13728,7 +13724,7 @@
           },
           "key": "testnet",
           "label": "Testnet",
-          "url": "https://rpc.testnet.fastnear.com"
+          "url": "https://archival-rpc.testnet.fastnear.com"
         }
       ],
       "requestMethod": "tx",
@@ -14085,7 +14081,7 @@
           },
           "key": "mainnet",
           "label": "Mainnet",
-          "url": "https://rpc.mainnet.fastnear.com"
+          "url": "https://archival-rpc.mainnet.fastnear.com"
         },
         {
           "defaultFields": {
@@ -14093,7 +14089,7 @@
           },
           "key": "testnet",
           "label": "Testnet",
-          "url": "https://rpc.testnet.fastnear.com"
+          "url": "https://archival-rpc.testnet.fastnear.com"
         }
       ],
       "requestMethod": "EXPERIMENTAL_validators_ordered",
@@ -14352,15 +14348,15 @@
           },
           "key": "mainnet",
           "label": "Mainnet",
-          "url": "https://rpc.mainnet.fastnear.com"
+          "url": "https://archival-rpc.mainnet.fastnear.com"
         },
         {
           "defaultFields": {
-            "epoch_id": "3KWUtEFtzmmmc93EYpD3ehb4LE11YJ2jCFkqWhygkbaR"
+            "epoch_id": "BARiarhzfSL7G737ik4AukX9sFYH1iR3dYU3KNUAvF3e"
           },
           "key": "testnet",
           "label": "Testnet",
-          "url": "https://rpc.testnet.fastnear.com"
+          "url": "https://archival-rpc.testnet.fastnear.com"
         }
       ],
       "requestMethod": "validators",
@@ -14458,7 +14454,7 @@
               "id": "fastnear",
               "method": "validators",
               "params": {
-                "epoch_id": "3KWUtEFtzmmmc93EYpD3ehb4LE11YJ2jCFkqWhygkbaR"
+                "epoch_id": "BARiarhzfSL7G737ik4AukX9sFYH1iR3dYU3KNUAvF3e"
               }
             },
             "headers": {},


### PR DESCRIPTION
## Problem

About **half** the RPC operation "Send request" examples were broken. They pinned specific historical references (block/chunk/receipt/tx/epoch) that the public **non-archival** RPC garbage-collects after a few epochs — so clicking **Send** returned `UNKNOWN_BLOCK` / `UNKNOWN_CHUNK` / `UNKNOWN_RECEIPT` / `UNKNOWN_EPOCH` or timed out. They worked when authored, then rotted.

Verified with a live harness firing every example's exact body at its endpoint: **41/80 example requests passing** before this change.

## Fix (all verified live — now 74/80 pass)

| Fix | Ops |
|---|---|
| **Archival endpoints** (never GC) | block-by-id/height, chunk-by-hash, chunk-by-block-shard, gas-price-by-block, congestion-level, receipt, receipt-to-tx, tx-status, EXPERIMENTAL-tx-status, validators-ordered, validators-by-epoch, light-client-block-proof, next-light-client-block, light-client-proof ×2 |
| **`finality:"final"`** (latest, evergreen) | block_effects |
| **`type: receipt`→`transaction`** (fields matched transaction) | light_client_proof, EXPERIMENTAL_light_client_proof |
| **Real params + `block_height` anchor** | EXPERIMENTAL_receipt_to_tx (both nets) |
| **Fresh testnet epoch** (testnet reset) | validators_by_epoch (testnet) |
| **Small contract** (was `TOO_LARGE`) | view_state (testnet → `counter.testnet`) |

The remaining **6 "failures" are write methods** (`broadcast_tx_async/commit`, `send_tx`) that inherently need a real one-time signed transaction — mike-docs already treats them as shape-only. `health` returns a valid `null`.

## How

Root fix is in **mike-docs** (per-op `rpcs/*.yaml` `servers:` + example params, mirrored in `scripts/rpc-example-config.js` so `refresh-examples` keeps them). This PR is the **regenerated + vendored** `generatedFastnearPageModels.json`.

**Paired source branch:** `mike-docs` `fix/rpc-examples-evergreen`.

## Validation
- `yarn ci:locale-quality` — green (en+ru build + page-model audit 79/79 + indexing)
- Live harness: 74/80 example requests return a valid response (was 41)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H8DjaLbA7Ed63XuSAENrJ7